### PR TITLE
Define a constant for the ping-interval.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@ var defaults = {
   host: 'https://api.flowhub.io'
 };
 
+Object.defineProperty(exports, "PING_INTERVAL", {
+    value:      10 * 60 * 1000,
+    enumerable: true
+  });
+
 exports.Runtime = function (runtime, options) {
   if (typeof runtime !== 'object') {
     throw new Error('Runtime options expected');


### PR DESCRIPTION
This way clients can use a common default. Later we can also use this to detect dead clients (e.g. missed >3 pings).